### PR TITLE
🧭  Interaction b/w table of contents and headings

### DIFF
--- a/app/components/TableOfContents.tsx
+++ b/app/components/TableOfContents.tsx
@@ -114,10 +114,19 @@ function useHeaders() {
     headingsSet.current.add(e);
   });
 
-  const headings: Heading[] = elements.map((heading) => {
-    const { innerText: title, innerHTML: titleHTML, id } = heading;
-    return { title, titleHTML, id, level: Number(heading.tagName.slice(1)) };
-  });
+  const headings: Heading[] = elements
+    .map((heading) => {
+      return {
+        level: Number(heading.tagName.slice(1)),
+        id: heading.id,
+        text: heading.querySelector('.heading-text'),
+      };
+    })
+    .filter((h) => !!h.text)
+    .map(({ level, text, id }) => {
+      const { innerText: title, innerHTML: titleHTML } = text as HTMLSpanElement;
+      return { title, titleHTML, id, level };
+    });
 
   return { activeId, highlight, headings };
 }

--- a/app/myst-to-react/heading.tsx
+++ b/app/myst-to-react/heading.tsx
@@ -2,8 +2,9 @@ import { Heading } from 'myst-spec';
 import { NodeRenderer } from './types';
 import { createElement as e } from 'react';
 
+const HELP_TEXT = 'Permalink to this Section';
+
 const Heading: NodeRenderer<Heading> = (node, children) => {
-  // TODO: this should be in css
   const { enumerator, depth, key, identifier } = node;
   const id = identifier || key;
   const textContent = (
@@ -11,14 +12,16 @@ const Heading: NodeRenderer<Heading> = (node, children) => {
       <a
         className="select-none absolute top-0 left-0 -translate-x-[100%] font-normal pr-3 no-underline transition-opacity opacity-0 group-hover:opacity-70"
         href={`#${id}`}
-        aria-label="Permalink to this Section"
+        title={HELP_TEXT}
+        aria-label={HELP_TEXT}
       >
         <span>#</span>
       </a>
       {enumerator && <span className="select-none mr-3">{enumerator}</span>}
-      {children}
+      <span className="heading-text">{children}</span>
     </>
   );
+  // The `heading-text` class picked up in the TableOfContents to select without the enumerator and "#" link
   return e(
     `h${depth}`,
     {


### PR DESCRIPTION
There was an unintended sideeffect of the header links #26. With the table of contents, which pulls in content HTML so that it can render math.

This PR no longer pulls in the header enumeration or the link to the navigation block!

![image](https://user-images.githubusercontent.com/913249/163035756-7c914835-90c7-4f4a-b250-e722ab46b118.png)

![image](https://user-images.githubusercontent.com/913249/163035887-d2ac8751-d835-4cb3-8cb9-d173b8dcab03.png)
