### PR TITLE
Add linkBlock renderer and demo file

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -31,7 +31,8 @@
         { "title": "Interactive Components", "slug": "interactive", "level": 2 },
         { "title": "Juptyer Outputs", "slug": "outputs", "level": 2 },
         { "title": "Examples", "slug": "examples", "level": 2 },
-        { "title": "Tables", "slug": "tables", "level": 2 }
+        { "title": "Tables", "slug": "tables", "level": 2 },
+        { "title": "Links", "slug": "links", "level": 2 }
       ]
     }
   }

--- a/app/content/demo/links.json
+++ b/app/content/demo/links.json
@@ -1,0 +1,136 @@
+{
+  "frontmatter": {
+    "title": "Links",
+    "description": "",
+    "date": "2022-01-17T00:46:35.123Z",
+    "name": "links"
+  },
+  "mdast": {
+    "type": "root",
+    "children": [
+      {
+        "type": "block",
+        "children": [
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "External link in a paragraph: ",
+                "key": "qx61HyFuwu"
+              },
+              {
+                "type": "link",
+                "url": "https://curvenote.com",
+                "title": "Curvenote",
+                "children": [
+                  {
+                    "type": "emphasis",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Go to curvenote"
+                      }
+                    ]
+                  }
+                ],
+                "key": "qx61HyFuww"
+              }
+            ],
+            "key": "onm8JPAn6g"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Internal link in a paragraph: ",
+                "key": "qx61HyFuwx"
+              },
+              {
+                "type": "link",
+                "url": "/demo/admonitions",
+                "title": "Admonitions",
+                "internal": true,
+                "children": [
+                  {
+                    "type": "emphasis",
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Go to admonitions"
+                      }
+                    ]
+                  }
+                ],
+                "key": "qx61HyFuwy"
+              }
+            ],
+            "key": "onm8JPAn6h"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "External link block: "
+              }
+            ],
+            "key": "BlfRanCg5i"
+          },
+          {
+            "type": "linkBlock",
+            "url": "https://curvenote.com",
+            "title": "Curvenote",
+            "thumbnail": "https://source.unsplash.com/random/200x200/?mountain",
+            "children": [
+              {
+                "type": "emphasis",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Go to curvenote"
+                  }
+                ]
+              }
+            ],
+            "key": "qx61HyFuxa"
+          },
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "text",
+                "value": "Internal link block: "
+              }
+            ],
+            "key": "BlfRanCg5j"
+          },
+          {
+            "type": "linkBlock",
+            "url": "/demo/admonitions",
+            "internal": true,
+            "title": "Admonitions",
+            "thumbnail": "https://source.unsplash.com/random/200x200/?mountain",
+            "children": [
+              {
+                "type": "emphasis",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Go to admonitions"
+                  }
+                ]
+              }
+            ],
+            "key": "qx61HyFuxb"
+          }
+        ],
+        "key": "linkblock"
+      }
+    ],
+    "key": "BlfRanCg5h"
+  },
+  "references": { "cite": { "order": [], "data": {} }, "footnotes": {} },
+  "sha256": "963a9095ce34f515552c8de359274f368f9803b96261332e485c5889e741195b"
+}

--- a/app/myst-to-react/links.tsx
+++ b/app/myst-to-react/links.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'myst-spec';
 import { NodeRenderer } from '~/myst-to-react';
 import { Link as RemixLink } from 'remix';
-import classNames from 'classnames';
 import { ExternalLinkIcon, LinkIcon } from '@heroicons/react/outline';
 
 type TransformedLink = Link & { internal?: boolean };
@@ -23,32 +22,35 @@ export const link: NodeRenderer<TransformedLink> = (node, children) => {
 };
 
 export const linkBlock: NodeRenderer<TransformedLink> = (node, children) => {
-  const iconClass = 'h-8 w-8 inline-block pl-2 mr-2 -translate-y-[1px]';
+  const iconClass = 'w-6 h-6 self-center transition-transform';
+  const containerClass =
+    'flex-1 p-4 block border font-normal hover:border-blue-500 dark:hover:border-blue-400 no-underline hover:text-blue-500 dark:hover:text-blue-400 text-gray-600 dark:text-gray-100 border-gray-200 dark:border-gray-500 rounded shadow-sm hover:shadow-lg dark:shadow-neutral-700';
   const internal = node.internal ?? false;
   const nested = (
-    <aside
-      key={node.key}
-      className={classNames(
-        'admonition rounded-md my-4 border-l-4 shadow-md dark:shadow-2xl dark:shadow-neutral-900 overflow-hidden border-blue-500',
-      )}
-    >
-      <div className="px-4 py-1 bg-gray-50 dark:bg-stone-800">
-        {internal && <LinkIcon className={iconClass} />}
-        {!internal && <ExternalLinkIcon className={iconClass} />}
-        {children}
+    <div className="flex align-middle h-full">
+      <div className="flex-grow">
+        {node.title}
+        <div className="text-xs text-gray-500 dark:text-gray-400">{children}</div>
       </div>
-    </aside>
+      {internal && <LinkIcon className={iconClass} />}
+      {!internal && <ExternalLinkIcon className={iconClass} />}
+    </div>
   );
 
   if (internal) {
     return (
-      <RemixLink key={node.key} to={node.url} prefetch="intent">
+      <RemixLink
+        key={node.key}
+        to={node.url}
+        prefetch="intent"
+        className={containerClass}
+      >
         {nested}
       </RemixLink>
     );
   }
   return (
-    <a key={node.key} target="_blank" href={node.url}>
+    <a key={node.key} target="_blank" href={node.url} className={containerClass}>
       {nested}
     </a>
   );

--- a/app/myst-to-react/links.tsx
+++ b/app/myst-to-react/links.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'myst-spec';
 import { NodeRenderer } from '~/myst-to-react';
 import { Link as RemixLink } from 'remix';
+import classNames from 'classnames';
+import { ExternalLinkIcon, LinkIcon } from '@heroicons/react/outline';
 
 type TransformedLink = Link & { internal?: boolean };
 
@@ -20,8 +22,41 @@ export const link: NodeRenderer<TransformedLink> = (node, children) => {
   );
 };
 
+export const linkBlock: NodeRenderer<TransformedLink> = (node, children) => {
+  const iconClass = 'h-8 w-8 inline-block pl-2 mr-2 -translate-y-[1px]';
+  const internal = node.internal ?? false;
+  const nested = (
+    <aside
+      key={node.key}
+      className={classNames(
+        'admonition rounded-md my-4 border-l-4 shadow-md dark:shadow-2xl dark:shadow-neutral-900 overflow-hidden border-blue-500',
+      )}
+    >
+      <div className="px-4 py-1 bg-gray-50 dark:bg-stone-800">
+        {internal && <LinkIcon className={iconClass} />}
+        {!internal && <ExternalLinkIcon className={iconClass} />}
+        {children}
+      </div>
+    </aside>
+  );
+
+  if (internal) {
+    return (
+      <RemixLink key={node.key} to={node.url} prefetch="intent">
+        {nested}
+      </RemixLink>
+    );
+  }
+  return (
+    <a key={node.key} target="_blank" href={node.url}>
+      {nested}
+    </a>
+  );
+};
+
 const LINK_RENDERERS = {
   link,
+  linkBlock,
 };
 
 export default LINK_RENDERERS;

--- a/app/myst-to-react/links.tsx
+++ b/app/myst-to-react/links.tsx
@@ -50,7 +50,13 @@ export const linkBlock: NodeRenderer<TransformedLink> = (node, children) => {
     );
   }
   return (
-    <a key={node.key} target="_blank" href={node.url} className={containerClass}>
+    <a
+      key={node.key}
+      className={containerClass}
+      target="_blank"
+      rel="noopener noreferrer"
+      href={node.url}
+    >
       {nested}
     </a>
   );


### PR DESCRIPTION
This adds a new page to the demo with links and link blocks

I also messed around to make a renderer for the link blocks, pulling in some stuff from admonitions...

![image](https://user-images.githubusercontent.com/913249/164104257-555dedde-bf30-46dd-912c-bfc2be4e71b8.png)
