### PR TITLE
⏰ Add date-fns to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@remix-run/vercel": "^1.6.0",
         "ansi-to-react": "^6.1.6",
         "classnames": "^2.3.1",
+        "date-fns": "^2.28.0",
         "lodash.throttle": "^4.1.1",
         "myst-spec": "^0.0.4",
         "mystjs": "^0.0.5",
@@ -4548,7 +4549,6 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "dev": true,
       "engines": {
         "node": ">=0.11"
       },
@@ -16911,8 +16911,7 @@
     "date-fns": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "dev": true
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "deasync": {
       "version": "0.1.24",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@remix-run/vercel": "^1.6.0",
     "ansi-to-react": "^6.1.6",
     "classnames": "^2.3.1",
+    "date-fns": "^2.28.0",
     "lodash.throttle": "^4.1.1",
     "myst-spec": "^0.0.4",
     "mystjs": "^0.0.5",


### PR DESCRIPTION
Saw this error with `curvenote start`:
![image](https://user-images.githubusercontent.com/9453731/175474015-9a259036-4f00-4c91-866d-7d25464e3d53.png)

Looks like `date-fns` was getting installed as a dependency somewhere but needs to be listed in `package.json` to eliminate this warning.